### PR TITLE
docs: addBinding supported in Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Our fix disables the automatic `Runtime.Enable` command on every frame. Instead,
 
 🔴 Cons: None are discovered so far.
 
-*This approach is supported only in Puppeteer. Playwright support is coming soon, stay tuned.*
-
 #### 2. Create a new isolated context via `Page.createIsolatedWorld` and save its ID.
 🟢 Pros: All your code will be executed in a separate isolated world, preventing page scripts from detecting your changes via MutationObserver and other techniques.
 


### PR DESCRIPTION
Delete the sentence _This approach is supported only in Puppeteer. Playwright support is coming soon, stay tuned._ in the chapter [_1. Create a new binding in the main world, call it and save its context ID._](https://github.com/rebrowser/rebrowser-patches#1-create-a-new-binding-in-the-main-world-call-it-and-save-its-context-id) (See commit [playwright: add addBinding method to fix Runtime.Enable leaks `#39912bc`](https://github.com/rebrowser/rebrowser-patches/commit/39912bc50f236f43330adbd11ac6dd1b71bb38fb))

